### PR TITLE
Fix Language Selector Bug

### DIFF
--- a/mobile-app/src/LookUpScreen/TranslationPreset.tsx
+++ b/mobile-app/src/LookUpScreen/TranslationPreset.tsx
@@ -59,7 +59,7 @@ export const TranslationPreset: TranslationPreset = ({
       ...preset,
       translationLanguage,
     });
-  }, []);
+  }, [preset]);
 
   const selectTranslationLanguage = useCallback(() => {
     navigation.navigate('LanguageSelector', {


### PR DESCRIPTION
This addresses issue #7 

The issue was related to memoization.

An instance of a `preset` containing the `sourceLanguage` was being cached from the first render. 
As a result, when the function was executed, it returned to its previous state.
 By adding it to the dependencies array, we update the execution of this function when the source language changes.