### PR TITLE
LookUp Screen SafeArea Fix

### DIFF
--- a/mobile-app/src/LookUpScreen.tsx
+++ b/mobile-app/src/LookUpScreen.tsx
@@ -15,8 +15,8 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context'
 import { useTheme } from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLanguageDeck } from './languageDeck/useLanguageDeck';
 import { LanguagesContext } from './languages/LanguagesContainer';
 import { InlineLoader } from './loaders/InlineLoader';

--- a/mobile-app/src/LookUpScreen.tsx
+++ b/mobile-app/src/LookUpScreen.tsx
@@ -11,11 +11,11 @@ import React, { FC, useCallback, useContext, useEffect, useState } from 'react';
 import {
   Alert,
   Keyboard,
-  SafeAreaView,
   StyleSheet,
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context'
 import { useTheme } from 'react-native-paper';
 import { useLanguageDeck } from './languageDeck/useLanguageDeck';
 import { LanguagesContext } from './languages/LanguagesContainer';


### PR DESCRIPTION
I suppose this problem occurs due to outdated libs.

This issue https://github.com/react-navigation/react-navigation/issues/11664#issue-1962283759 helped to solve this.